### PR TITLE
add background refresh with cached snapshots and metric history

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -4,6 +4,7 @@
   "description": "Monitor and manage your Qdrant clusters directly from Chrome",
   "version": "0.1.3",
   "permissions": [
+    "alarms",
     "storage"
   ],
   "host_permissions": [

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,7 +1,36 @@
+import { QdrantApi } from './lib/qdrant-api';
+import * as storage from './lib/storage';
+
+const REFRESH_ALARM_NAME = 'qdrant-background-refresh';
+const REFRESH_PERIOD_MINUTES = 5;
+
 interface PendingUpdate {
   version: string;
   detectedAt: string;
   previousVersion: string;
+}
+
+async function refreshCluster(clusterId: string, url: string, apiKey?: string): Promise<void> {
+  const attemptedAt = new Date().toISOString();
+  try {
+    const api = new QdrantApi(url, apiKey);
+    const data = await api.getDashboardData();
+    await storage.saveDashboardSnapshot(clusterId, data, attemptedAt);
+  } catch (error) {
+    await storage.recordClusterRefreshFailure(clusterId, (error as Error).message, attemptedAt);
+  }
+}
+
+async function refreshAllClusters(): Promise<void> {
+  const clusters = await storage.getClusters();
+  await Promise.all(clusters.map(cluster => refreshCluster(cluster.id, cluster.url, cluster.apiKey)));
+}
+
+function scheduleBackgroundRefresh(): void {
+  chrome.alarms.create(REFRESH_ALARM_NAME, {
+    delayInMinutes: 1,
+    periodInMinutes: REFRESH_PERIOD_MINUTES,
+  });
 }
 
 chrome.runtime.onUpdateAvailable.addListener(async (details) => {
@@ -17,5 +46,17 @@ chrome.runtime.onUpdateAvailable.addListener(async (details) => {
 chrome.runtime.onInstalled.addListener(async (details) => {
   if (details.reason === 'update' || details.reason === 'install') {
     await chrome.storage.local.remove('pendingUpdate');
+  }
+  scheduleBackgroundRefresh();
+  await refreshAllClusters();
+});
+
+chrome.runtime.onStartup.addListener(() => {
+  scheduleBackgroundRefresh();
+});
+
+chrome.alarms.onAlarm.addListener((alarm) => {
+  if (alarm.name === REFRESH_ALARM_NAME) {
+    void refreshAllClusters();
   }
 });

--- a/src/dashboard/Dashboard.tsx
+++ b/src/dashboard/Dashboard.tsx
@@ -33,7 +33,7 @@ export function Dashboard() {
   const [cluster, setCluster] = useState<ClusterConfig | null>(null);
   const [activeTab, setActiveTab] = useState<TabName>('overview');
   const [insightsFilter, setInsightsFilter] = useState<InsightsFilter>(DEFAULT_INSIGHTS_FILTER);
-  const { data, loading, error, capturedAt, history, refresh } = useDashboardData(cluster);
+  const { data, loading, error, capturedAt, history, refreshState, refresh } = useDashboardData(cluster);
 
   const navigateToInsights = (filterOverride?: Partial<InsightsFilter>) => {
     setInsightsFilter({ ...DEFAULT_INSIGHTS_FILTER, ...filterOverride });
@@ -129,7 +129,7 @@ export function Dashboard() {
             })}
           </div>
 
-          {activeTab === 'overview' && <OverviewTab data={data} history={history} capturedAt={capturedAt} />}
+          {activeTab === 'overview' && <OverviewTab data={data} history={history} capturedAt={capturedAt} refreshState={refreshState} />}
           {activeTab === 'collections' && <CollectionsTab data={data} insights={insights} cluster={cluster} onRefresh={refresh} onNavigateInsights={navigateToInsights} />}
           {activeTab === 'shards' && <ShardsTab data={data} />}
           {activeTab === 'optimizations' && <OptimizationsTab data={data} cluster={cluster} />}

--- a/src/dashboard/Dashboard.tsx
+++ b/src/dashboard/Dashboard.tsx
@@ -32,9 +32,8 @@ const TABS: { key: TabName; label: string }[] = [
 export function Dashboard() {
   const [cluster, setCluster] = useState<ClusterConfig | null>(null);
   const [activeTab, setActiveTab] = useState<TabName>('overview');
-  const [lastUpdated, setLastUpdated] = useState('');
   const [insightsFilter, setInsightsFilter] = useState<InsightsFilter>(DEFAULT_INSIGHTS_FILTER);
-  const { data, loading, error, refresh } = useDashboardData(cluster);
+  const { data, loading, error, capturedAt, history, refresh } = useDashboardData(cluster);
 
   const navigateToInsights = (filterOverride?: Partial<InsightsFilter>) => {
     setInsightsFilter({ ...DEFAULT_INSIGHTS_FILTER, ...filterOverride });
@@ -59,16 +58,13 @@ export function Dashboard() {
     if (cluster) refresh();
   }, [cluster]);
 
-  useEffect(() => {
-    if (data) setLastUpdated(new Date().toLocaleTimeString());
-  }, [data]);
-
   const insights: Insight[] = data ? runRules(data) : [];
   const criticalCount = insights.filter(i => i.level === 'critical').length;
   const warningCount = insights.filter(i => i.level === 'warning').length;
   const version = data?.telemetry?.app?.version;
   const nodeCount = Object.keys(data?.nodeTelemetry || {}).length;
   const totalPeers = data?.cluster?.peers ? Object.keys(data.cluster.peers).length : 1;
+  const lastUpdated = capturedAt ? new Date(capturedAt).toLocaleTimeString() : '';
 
   if (!cluster) {
     return <div className="container"><div className="error-box">No cluster specified. Open a cluster from the popup.</div></div>;
@@ -133,7 +129,7 @@ export function Dashboard() {
             })}
           </div>
 
-          {activeTab === 'overview' && <OverviewTab data={data} />}
+          {activeTab === 'overview' && <OverviewTab data={data} history={history} capturedAt={capturedAt} />}
           {activeTab === 'collections' && <CollectionsTab data={data} insights={insights} cluster={cluster} onRefresh={refresh} onNavigateInsights={navigateToInsights} />}
           {activeTab === 'shards' && <ShardsTab data={data} />}
           {activeTab === 'optimizations' && <OptimizationsTab data={data} cluster={cluster} />}

--- a/src/dashboard/hooks/useDashboardData.ts
+++ b/src/dashboard/hooks/useDashboardData.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect } from 'react';
-import type { DashboardData, ClusterConfig, MetricsHistorySample } from '../../lib/types';
+import type { DashboardData, ClusterConfig, ClusterRefreshState, MetricsHistorySample } from '../../lib/types';
 import { QdrantApi } from '../../lib/qdrant-api';
 import * as storage from '../../lib/storage';
 
@@ -9,6 +9,7 @@ interface UseDashboardDataResult {
   error: string | null;
   capturedAt: string | null;
   history: MetricsHistorySample[];
+  refreshState: ClusterRefreshState | null;
   refresh: () => void;
 }
 
@@ -18,18 +19,21 @@ export function useDashboardData(cluster: ClusterConfig | null): UseDashboardDat
   const [error, setError] = useState<string | null>(null);
   const [capturedAt, setCapturedAt] = useState<string | null>(null);
   const [history, setHistory] = useState<MetricsHistorySample[]>([]);
+  const [refreshState, setRefreshState] = useState<ClusterRefreshState | null>(null);
 
   const loadCachedData = useCallback(async () => {
     if (!cluster) {
       setData(null);
       setCapturedAt(null);
       setHistory([]);
+      setRefreshState(null);
       return;
     }
 
-    const [snapshot, storedHistory] = await Promise.all([
+    const [snapshot, storedHistory, storedRefreshState] = await Promise.all([
       storage.getDashboardSnapshot(cluster.id),
       storage.getMetricsHistory(cluster.id),
+      storage.getClusterRefreshState(cluster.id),
     ]);
 
     if (snapshot) {
@@ -40,6 +44,7 @@ export function useDashboardData(cluster: ClusterConfig | null): UseDashboardDat
       setCapturedAt(null);
     }
     setHistory(storedHistory);
+    setRefreshState(storedRefreshState);
   }, [cluster?.id]);
 
   useEffect(() => {
@@ -55,17 +60,20 @@ export function useDashboardData(cluster: ClusterConfig | null): UseDashboardDat
       const result = await api.getDashboardData();
       const snapshot = await storage.saveDashboardSnapshot(cluster.id, result);
       const storedHistory = await storage.getMetricsHistory(cluster.id);
+      const storedRefreshState = await storage.getClusterRefreshState(cluster.id);
       setData(result);
       setCapturedAt(snapshot.capturedAt);
       setHistory(storedHistory);
+      setRefreshState(storedRefreshState);
     } catch (e) {
       const message = (e as Error).message;
       await storage.recordClusterRefreshFailure(cluster.id, message);
+      setRefreshState(await storage.getClusterRefreshState(cluster.id));
       setError(`Failed to load live data: ${message}`);
     } finally {
       setLoading(false);
     }
   }, [cluster?.id, cluster?.url, cluster?.apiKey]);
 
-  return { data, loading, error, capturedAt, history, refresh };
+  return { data, loading, error, capturedAt, history, refreshState, refresh };
 }

--- a/src/dashboard/hooks/useDashboardData.ts
+++ b/src/dashboard/hooks/useDashboardData.ts
@@ -1,11 +1,14 @@
-import { useState, useCallback } from 'react';
-import type { DashboardData, ClusterConfig } from '../../lib/types';
+import { useState, useCallback, useEffect } from 'react';
+import type { DashboardData, ClusterConfig, MetricsHistorySample } from '../../lib/types';
 import { QdrantApi } from '../../lib/qdrant-api';
+import * as storage from '../../lib/storage';
 
 interface UseDashboardDataResult {
   data: DashboardData | null;
   loading: boolean;
   error: string | null;
+  capturedAt: string | null;
+  history: MetricsHistorySample[];
   refresh: () => void;
 }
 
@@ -13,6 +16,35 @@ export function useDashboardData(cluster: ClusterConfig | null): UseDashboardDat
   const [data, setData] = useState<DashboardData | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [capturedAt, setCapturedAt] = useState<string | null>(null);
+  const [history, setHistory] = useState<MetricsHistorySample[]>([]);
+
+  const loadCachedData = useCallback(async () => {
+    if (!cluster) {
+      setData(null);
+      setCapturedAt(null);
+      setHistory([]);
+      return;
+    }
+
+    const [snapshot, storedHistory] = await Promise.all([
+      storage.getDashboardSnapshot(cluster.id),
+      storage.getMetricsHistory(cluster.id),
+    ]);
+
+    if (snapshot) {
+      setData(snapshot.data);
+      setCapturedAt(snapshot.capturedAt);
+    } else {
+      setData(null);
+      setCapturedAt(null);
+    }
+    setHistory(storedHistory);
+  }, [cluster?.id]);
+
+  useEffect(() => {
+    void loadCachedData();
+  }, [loadCachedData]);
 
   const refresh = useCallback(async () => {
     if (!cluster) return;
@@ -21,13 +53,19 @@ export function useDashboardData(cluster: ClusterConfig | null): UseDashboardDat
     try {
       const api = new QdrantApi(cluster.url, cluster.apiKey);
       const result = await api.getDashboardData();
+      const snapshot = await storage.saveDashboardSnapshot(cluster.id, result);
+      const storedHistory = await storage.getMetricsHistory(cluster.id);
       setData(result);
+      setCapturedAt(snapshot.capturedAt);
+      setHistory(storedHistory);
     } catch (e) {
-      setError(`Failed to load data: ${(e as Error).message}`);
+      const message = (e as Error).message;
+      await storage.recordClusterRefreshFailure(cluster.id, message);
+      setError(`Failed to load live data: ${message}`);
     } finally {
       setLoading(false);
     }
-  }, [cluster?.url, cluster?.apiKey]);
+  }, [cluster?.id, cluster?.url, cluster?.apiKey]);
 
-  return { data, loading, error, refresh };
+  return { data, loading, error, capturedAt, history, refresh };
 }

--- a/src/dashboard/tabs/OverviewTab.tsx
+++ b/src/dashboard/tabs/OverviewTab.tsx
@@ -1,8 +1,8 @@
-import type { DashboardData } from '../../lib/types';
-import { formatBytes, formatDuration } from '../../lib/format';
+import type { DashboardData, MetricsHistorySample } from '../../lib/types';
+import { formatBytes, formatDuration, formatNumber } from '../../lib/format';
 import { SummaryStats } from '../SummaryStats';
 
-export function OverviewTab({ data }: { data: DashboardData }) {
+export function OverviewTab({ data, history, capturedAt }: { data: DashboardData; history: MetricsHistorySample[]; capturedAt: string | null }) {
   const app = data.telemetry?.app;
   const sys = app?.system;
   const features = app?.features || {};
@@ -11,6 +11,12 @@ export function OverviewTab({ data }: { data: DashboardData }) {
 
   const startup = app?.startup ? new Date(app.startup).toLocaleString() : 'N/A';
   const uptime = app?.startup ? formatDuration(Date.now() - new Date(app.startup).getTime()) : 'N/A';
+  const firstSample = history[0];
+  const latestSample = history[history.length - 1];
+  const historyWindow = firstSample && latestSample
+    ? formatDuration(new Date(latestSample.capturedAt).getTime() - new Date(firstSample.capturedAt).getTime())
+    : 'N/A';
+  const pointDelta = firstSample && latestSample ? latestSample.totalPoints - firstSample.totalPoints : 0;
 
   const memItems = [
     { name: 'Resident', bytes: mem?.resident_bytes, color: '#e94560', desc: 'Physical memory used' },
@@ -65,6 +71,18 @@ export function OverviewTab({ data }: { data: DashboardData }) {
             </div>
           );
         })}
+      </div>
+      <div className="card">
+        <h2>Cached Monitoring</h2>
+        <table className="info-table">
+          <tbody>
+            <tr><td>Last Successful Snapshot</td><td>{capturedAt ? new Date(capturedAt).toLocaleString() : 'N/A'}</td></tr>
+            <tr><td>History Samples</td><td>{history.length}</td></tr>
+            <tr><td>History Window</td><td>{history.length > 1 ? historyWindow : 'Waiting for another sample'}</td></tr>
+            <tr><td>Point Change</td><td>{history.length > 1 ? `${pointDelta >= 0 ? '+' : ''}${formatNumber(pointDelta)}` : 'N/A'}</td></tr>
+            <tr><td>Latest Indexed Vectors</td><td>{latestSample ? formatNumber(latestSample.totalIndexedVectors) : 'N/A'}</td></tr>
+          </tbody>
+        </table>
       </div>
     </div>
     </>

--- a/src/dashboard/tabs/OverviewTab.tsx
+++ b/src/dashboard/tabs/OverviewTab.tsx
@@ -1,8 +1,8 @@
-import type { DashboardData, MetricsHistorySample } from '../../lib/types';
+import type { ClusterRefreshState, DashboardData, MetricsHistorySample } from '../../lib/types';
 import { formatBytes, formatDuration, formatNumber } from '../../lib/format';
 import { SummaryStats } from '../SummaryStats';
 
-export function OverviewTab({ data, history, capturedAt }: { data: DashboardData; history: MetricsHistorySample[]; capturedAt: string | null }) {
+export function OverviewTab({ data, history, capturedAt, refreshState }: { data: DashboardData; history: MetricsHistorySample[]; capturedAt: string | null; refreshState: ClusterRefreshState | null }) {
   const app = data.telemetry?.app;
   const sys = app?.system;
   const features = app?.features || {};
@@ -17,6 +17,7 @@ export function OverviewTab({ data, history, capturedAt }: { data: DashboardData
     ? formatDuration(new Date(latestSample.capturedAt).getTime() - new Date(firstSample.capturedAt).getTime())
     : 'N/A';
   const pointDelta = firstSample && latestSample ? latestSample.totalPoints - firstSample.totalPoints : 0;
+  const lastFailedAt = refreshState?.lastError ? refreshState.lastAttemptAt : null;
 
   const memItems = [
     { name: 'Resident', bytes: mem?.resident_bytes, color: '#e94560', desc: 'Physical memory used' },
@@ -81,6 +82,8 @@ export function OverviewTab({ data, history, capturedAt }: { data: DashboardData
             <tr><td>History Window</td><td>{history.length > 1 ? historyWindow : 'Waiting for another sample'}</td></tr>
             <tr><td>Point Change</td><td>{history.length > 1 ? `${pointDelta >= 0 ? '+' : ''}${formatNumber(pointDelta)}` : 'N/A'}</td></tr>
             <tr><td>Latest Indexed Vectors</td><td>{latestSample ? formatNumber(latestSample.totalIndexedVectors) : 'N/A'}</td></tr>
+            <tr><td>Last Failed Refresh</td><td>{lastFailedAt ? new Date(lastFailedAt).toLocaleString() : 'None'}</td></tr>
+            <tr><td>Last Error</td><td>{refreshState?.lastError || 'None'}</td></tr>
           </tbody>
         </table>
       </div>

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -1,0 +1,48 @@
+import type { DashboardData, MetricsHistorySample } from './types';
+
+export function createMetricsSample(
+  clusterId: string,
+  capturedAt: string,
+  data: DashboardData,
+): MetricsHistorySample {
+  let totalPoints = 0;
+  let totalVectors = 0;
+  let hasVectorCounts = false;
+  let totalIndexedVectors = 0;
+  let totalSegments = 0;
+
+  const collections = data.collections.flatMap((collection) => {
+    const info = data.collectionDetails[collection]?.info;
+    if (!info) return [];
+
+    totalPoints += info.points_count || 0;
+    totalIndexedVectors += info.indexed_vectors_count || 0;
+    totalSegments += info.segments_count || 0;
+
+    const vectors = typeof info.vectors_count === 'number' ? info.vectors_count : null;
+    if (vectors !== null) {
+      totalVectors += vectors;
+      hasVectorCounts = true;
+    }
+
+    return [{
+      collection,
+      status: info.status || 'unknown',
+      points: info.points_count || 0,
+      vectors,
+      indexedVectors: info.indexed_vectors_count || 0,
+      segments: info.segments_count || 0,
+    }];
+  });
+
+  return {
+    clusterId,
+    capturedAt,
+    qdrantUp: 1,
+    totalPoints,
+    totalVectors: hasVectorCounts ? totalVectors : null,
+    totalIndexedVectors,
+    totalSegments,
+    collections,
+  };
+}

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,4 +1,16 @@
-import type { ClusterConfig } from './types';
+import type {
+  CachedDashboardSnapshot,
+  ClusterConfig,
+  ClusterRefreshState,
+  DashboardData,
+  MetricsHistorySample,
+} from './types';
+import { createMetricsSample } from './metrics';
+
+const SNAPSHOT_PREFIX = 'dashboardSnapshot:';
+const REFRESH_STATE_PREFIX = 'clusterRefreshState:';
+const HISTORY_PREFIX = 'metricsHistory:';
+const MAX_HISTORY_SAMPLES = 288;
 
 export async function getClusters(): Promise<ClusterConfig[]> {
   const data = await chrome.storage.local.get('clusters') as { clusters?: ClusterConfig[] };
@@ -33,4 +45,56 @@ export async function updateCluster(id: string, updates: Partial<ClusterConfig>)
 export async function removeCluster(id: string): Promise<void> {
   const clusters = await getClusters();
   await saveClusters(clusters.filter(c => c.id !== id));
+  await chrome.storage.local.remove([
+    `${SNAPSHOT_PREFIX}${id}`,
+    `${REFRESH_STATE_PREFIX}${id}`,
+    `${HISTORY_PREFIX}${id}`,
+  ]);
+}
+
+export async function getDashboardSnapshot(clusterId: string): Promise<CachedDashboardSnapshot | null> {
+  const key = `${SNAPSHOT_PREFIX}${clusterId}`;
+  const data = await chrome.storage.local.get(key) as Record<string, CachedDashboardSnapshot | undefined>;
+  return data[key] || null;
+}
+
+export async function saveDashboardSnapshot(clusterId: string, data: DashboardData, capturedAt = new Date().toISOString()): Promise<CachedDashboardSnapshot> {
+  const snapshot: CachedDashboardSnapshot = { clusterId, capturedAt, data };
+  await chrome.storage.local.set({ [`${SNAPSHOT_PREFIX}${clusterId}`]: snapshot });
+  await setClusterRefreshState({ clusterId, lastAttemptAt: capturedAt, lastSuccessAt: capturedAt });
+  await appendMetricsHistorySample(createMetricsSample(clusterId, capturedAt, data));
+  return snapshot;
+}
+
+export async function getClusterRefreshState(clusterId: string): Promise<ClusterRefreshState | null> {
+  const key = `${REFRESH_STATE_PREFIX}${clusterId}`;
+  const data = await chrome.storage.local.get(key) as Record<string, ClusterRefreshState | undefined>;
+  return data[key] || null;
+}
+
+export async function setClusterRefreshState(state: ClusterRefreshState): Promise<void> {
+  await chrome.storage.local.set({ [`${REFRESH_STATE_PREFIX}${state.clusterId}`]: state });
+}
+
+export async function recordClusterRefreshFailure(clusterId: string, error: string, attemptedAt = new Date().toISOString()): Promise<void> {
+  const previous = await getClusterRefreshState(clusterId);
+  await setClusterRefreshState({
+    clusterId,
+    lastAttemptAt: attemptedAt,
+    lastSuccessAt: previous?.lastSuccessAt,
+    lastError: error,
+  });
+}
+
+export async function getMetricsHistory(clusterId: string): Promise<MetricsHistorySample[]> {
+  const key = `${HISTORY_PREFIX}${clusterId}`;
+  const data = await chrome.storage.local.get(key) as Record<string, MetricsHistorySample[] | undefined>;
+  return data[key] || [];
+}
+
+export async function appendMetricsHistorySample(sample: MetricsHistorySample): Promise<void> {
+  const key = `${HISTORY_PREFIX}${sample.clusterId}`;
+  const history = await getMetricsHistory(sample.clusterId);
+  const next = [...history, sample].slice(-MAX_HISTORY_SAMPLES);
+  await chrome.storage.local.set({ [key]: next });
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -39,6 +39,7 @@ export interface ClusterInfo {
 export interface CollectionInfo {
   status: string;
   optimizer_status: string | { error: string };
+  vectors_count?: number;
   indexed_vectors_count: number;
   points_count: number;
   segments_count: number;
@@ -336,6 +337,41 @@ export interface DashboardData {
   collectionDetails: Record<string, CollectionDetail>;
   telemetry: Telemetry | null;
   nodeTelemetry: Record<string, Telemetry>;
+}
+
+// --- Cached Monitoring Data ---
+
+export interface CachedDashboardSnapshot {
+  clusterId: string;
+  capturedAt: string;
+  data: DashboardData;
+}
+
+export interface ClusterRefreshState {
+  clusterId: string;
+  lastAttemptAt: string;
+  lastSuccessAt?: string;
+  lastError?: string;
+}
+
+export interface CollectionMetricSample {
+  collection: string;
+  status: string;
+  points: number;
+  vectors: number | null;
+  indexedVectors: number;
+  segments: number;
+}
+
+export interface MetricsHistorySample {
+  clusterId: string;
+  capturedAt: string;
+  qdrantUp: 0 | 1;
+  totalPoints: number;
+  totalVectors: number | null;
+  totalIndexedVectors: number;
+  totalSegments: number;
+  collections: CollectionMetricSample[];
 }
 
 // --- Insights / Rules ---

--- a/src/popup/ClusterList.tsx
+++ b/src/popup/ClusterList.tsx
@@ -1,15 +1,21 @@
 import { useState, useEffect } from 'react';
-import type { ClusterConfig } from '../lib/types';
+import type { ClusterConfig, ClusterRefreshState } from '../lib/types';
 import { QdrantApi } from '../lib/qdrant-api';
 
 interface Props {
   clusters: ClusterConfig[];
+  refreshStates: Record<string, ClusterRefreshState>;
   onEdit: (c: ClusterConfig) => void;
   onDelete: (id: string) => void;
   onOpen: (id: string) => void;
 }
 
-export function ClusterList({ clusters, onEdit, onDelete, onOpen }: Props) {
+function formatRefreshState(state?: ClusterRefreshState): string {
+  if (!state?.lastSuccessAt) return 'No cached snapshot yet';
+  return `Cached ${new Date(state.lastSuccessAt).toLocaleString()}`;
+}
+
+export function ClusterList({ clusters, refreshStates, onEdit, onDelete, onOpen }: Props) {
   const [health, setHealth] = useState<Record<string, 'checking' | 'online' | 'offline'>>({});
 
   useEffect(() => {
@@ -45,6 +51,7 @@ export function ClusterList({ clusters, onEdit, onDelete, onOpen }: Props) {
           <div className="cluster-item-info" onClick={() => onOpen(c.id)}>
             <div className="cluster-item-name">{c.name}</div>
             <div className="cluster-item-url">{c.url}</div>
+            <div className="cluster-item-cache">{formatRefreshState(refreshStates[c.id])}</div>
           </div>
           <div className="cluster-item-actions">
             <button className="edit-btn" onClick={(e) => { e.stopPropagation(); onEdit(c); }} title="Edit">&#9998;</button>

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import type { ClusterConfig } from '../lib/types';
+import type { ClusterConfig, ClusterRefreshState } from '../lib/types';
 import * as storage from '../lib/storage';
 import { ClusterList } from './ClusterList';
 import { ClusterForm } from './ClusterForm';
@@ -8,11 +8,18 @@ import { ThemeToggle } from '../components/ThemeToggle';
 
 export function Popup() {
   const [clusters, setClusters] = useState<ClusterConfig[]>([]);
+  const [refreshStates, setRefreshStates] = useState<Record<string, ClusterRefreshState>>({});
   const [view, setView] = useState<'list' | 'form'>('list');
   const [editing, setEditing] = useState<ClusterConfig | null>(null);
 
   const loadClusters = async () => {
-    setClusters(await storage.getClusters());
+    const nextClusters = await storage.getClusters();
+    const states = await Promise.all(nextClusters.map(c => storage.getClusterRefreshState(c.id)));
+    const refreshStateEntries = states
+      .filter((state): state is ClusterRefreshState => state !== null)
+      .map(state => [state.clusterId, state]);
+    setClusters(nextClusters);
+    setRefreshStates(Object.fromEntries(refreshStateEntries));
   };
 
   useEffect(() => { loadClusters(); }, []);
@@ -52,7 +59,7 @@ export function Popup() {
         </div>
       </div>
       {view === 'list' ? (
-        <ClusterList clusters={clusters} onEdit={handleEdit} onDelete={handleDelete} onOpen={handleOpen} />
+        <ClusterList clusters={clusters} refreshStates={refreshStates} onEdit={handleEdit} onDelete={handleDelete} onOpen={handleOpen} />
       ) : (
         <ClusterForm initial={editing} onSave={handleSave} onCancel={handleCancel} />
       )}

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -141,6 +141,15 @@ body {
   font-family: monospace;
 }
 
+.cluster-item-cache {
+  font-size: 0.72rem;
+  color: var(--info);
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .cluster-item-actions {
   display: flex;
   gap: 4px;


### PR DESCRIPTION

### description:

  adds background refresh for configured qdrant clusters, stores the latest successful dashboard snapshot, and keeps a small metrics history

  benefits:
  - shows the last good data if a live refresh fails
  - shows when the cluster was last refreshed
  - stores history samples for future trend views
  - keeps refresh failures from erasing useful cluster data
  - adds cached monitoring info in the overview tab
  - shows cached snapshot time in the popup

fields description
  -  last successful snapshot: when the last good qdrant data was saved
  - last failed refresh: when the latest failed refresh happened
  - last error: why the latest refresh failed
  - history samples: how many saved metric records exist
  - history window: how much time the saved history covers
  - point change: how much total points changed over the saved history
  - latest indexed vectors: latest saved indexed vector count

 
### related issues #1 

<img width="580" height="455" alt="image" src="https://github.com/user-attachments/assets/e0a1d934-2096-41f5-916f-0e09da103945" />
